### PR TITLE
Fixed typographical error, changed appartment to apartment in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ Instead, it is sent along with the `phone_number` when the user submits it.
 
     The URL is POST {URL}/save_house_details
 
-    post : { estate_id: 1, contact_id: 1, appartment_name: "43A" }
+    post : { estate_id: 1, contact_id: 1, apartment_name: "43A" }
 
 ##### Response
 
     {
         "contact_id": "1",
         "estate_id": "1",
-        "appartment_id": 4
+        "apartment_id": 4
     }
 
 ### User Details (Profile)


### PR DESCRIPTION
@anyangocynthia, I've corrected a typographical error in the documentation of the [nyumba_kumi](https://github.com/anyangocynthia/nyumba_kumi) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
